### PR TITLE
Fix issue 261 - new response header "X-IC-Title-Encoded"

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -243,8 +243,8 @@ var Intercooler = Intercooler || (function() {
       document.title = xhr.getResponseHeader("X-IC-Title");
     }
 
-    if (xhr.getResponseHeader("X-IC-Title-ENCODED")) {
-      var decodedTitle = decodeURIComponent((xhr.getResponseHeader("X-IC-Title-ENCODED")).replace(/\+/g, '%20'));
+    if (xhr.getResponseHeader("X-IC-Title-Encoded")) {
+      var decodedTitle = decodeURIComponent((xhr.getResponseHeader("X-IC-Title-Encoded")).replace(/\+/g, '%20'));
       document.title = decodedTitle;
     }
 

--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -243,6 +243,11 @@ var Intercooler = Intercooler || (function() {
       document.title = xhr.getResponseHeader("X-IC-Title");
     }
 
+    if (xhr.getResponseHeader("X-IC-Title-ENCODED")) {
+      var decodedTitle = decodeURIComponent((xhr.getResponseHeader("X-IC-Title-ENCODED")).replace(/\+/g, '%20'));
+      document.title = decodedTitle;
+    }
+
     if (xhr.getResponseHeader("X-IC-Refresh")) {
       var pathsToRefresh = xhr.getResponseHeader("X-IC-Refresh").split(",");
       log(elt, "X-IC-Refresh: refreshing " + pathsToRefresh, "DEBUG");

--- a/www/_includes/response_api.html
+++ b/www/_includes/response_api.html
@@ -97,7 +97,15 @@
         <code>X-IC-Title</code>
       </td>
       <td>
-        Sets the title of the page/document to the given header value.
+        Sets the title of the page/document to the given header value. Please note that only ASCII characters are guaranteed to work. 
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>X-IC-Title-Encoded</code>
+      </td>
+      <td>
+        URI decodes the given header value and sets the title of the page/document to the decoded value. Use this header if you need to show UTF-8 characters in the title.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
The fix adds a new response header "X-IC-Title-Encoded" which decodes an URL encoded string.
By using the "X-IC-Title-Encoded" header you can URL encode an UTF-8 string on the server and show it correctly in the document title.