### PR TITLE
Fix for issue 268 - yOffset is not restored correctly after pressing the "Back" button

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1732,7 +1732,9 @@ var Intercooler = Intercooler || (function() {
         if (historyData) {
           processICResponse(historyData["content"], getTargetForHistory($('body')), true);
           if (historyData["yOffset"]) {
-            window.scrollTo(0, historyData["yOffset"])
+             setTimeout(function () {
+                window.scrollTo(0, historyData["yOffset"]);
+             }, 40);
           }
           return true;
         } else {


### PR DESCRIPTION
The reason why the current implementation doesn't work is that there is a `setTimeout` in `processICResponse` which performs the actual content swap. This means that it is still the old page that is shown when `window.scrollTo` is called in `handleHistoryNavigation`. To fix this we wrap `window.scrollTo` in a `setTimeout`. 