### PR TITLE
Fix to prevent 'strict mode does not allow assignment to unassigned variables' error

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -8,7 +8,7 @@ var Intercooler = Intercooler || (function() {
 
   // work around zepto build issue TODO - fix me
   if((typeof Zepto !== "undefined") && ($ == null)) {
-    $ = Zepto
+    window["$"] = Zepto
   }
 
   //--------------------------------------------------


### PR DESCRIPTION
I ran into this issue the other day when setting up a new bundling / minifying system for our project:

> Strict-mode does not allow assignment to undefined variables: $

Found someone with a similar issue here:

https://github.com/SortableJS/Sortable/issues/1004

And the resulting fix in Sortable.js was like so:

https://github.com/SortableJS/Sortable/blob/master/Sortable.js#L19

Tried the same in Intercooler and voila - it worked! Thought I'd share so this doesn't trip anyone else up in a similar situation. Thanks!