### PR TITLE
Add attribute to control credentials for SSE

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1049,14 +1049,15 @@ var Intercooler = Intercooler || (function() {
     elt = $(elt);
     if (getICAttribute(elt, 'ic-sse-src')) {
       var evtSrcUrl = getICAttribute(elt, 'ic-sse-src');
-      var eventSource = initEventSource(elt, evtSrcUrl);
+      var evtSrcWithCredentials = getICAttribute(elt, 'ic-sse-with-credentials') === 'true';
+      var eventSource = initEventSource(elt, evtSrcUrl, evtSrcWithCredentials);
       elt.data('ic-event-sse-source', eventSource);
       elt.data('ic-event-sse-map', {});
     }
   }
 
-  function initEventSource(elt, evtSrcUrl) {
-    var eventSource = Intercooler._internal.initEventSource(evtSrcUrl);
+  function initEventSource(elt, evtSrcUrl, evtSrcWithCredentials) {
+    var eventSource = Intercooler._internal.initEventSource(evtSrcUrl, evtSrcWithCredentials);
     eventSource.onmessage = function(e) {
       processICResponse(e.data, elt, false);
     };
@@ -2029,8 +2030,8 @@ var Intercooler = Intercooler || (function() {
     _internal: {
       init: init,
       replaceOrAddMethod: replaceOrAddMethod,
-      initEventSource: function(url) {
-        return new EventSource(url);
+      initEventSource: function(url, withCredentials) {
+        return new EventSource(url, {withCredentials: withCredentials});
       },
       globalEval: globalEval
     }

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -127,7 +127,7 @@
     });
 
     // server sent events mock
-    Intercooler._internal.initEventSource = function(url) {
+    Intercooler._internal.initEventSource = function(url, withCredentials) {
       var eventHandlers = {};
       var that = {
         close : function(){},
@@ -147,7 +147,9 @@
         },
         close : function () {
           that.closed = true;
-        }
+        },
+        url: url,
+        withCredentials: withCredentials
       };
       return that;
     };
@@ -2216,6 +2218,42 @@ QUnit.test("Script evaluation", function (assert) {
       function(assert) {
         assert.equal("foo", $("#sse-6-inner").html());
       });
+  </script>
+
+  <div id="sse-7" ic-sse-src="/foo" ic-sse-with-credentials="true">
+  <script>
+    intercoolerTest("test event source with credentials set to true",
+            function (assert) {
+              var mockSource = $("#sse-7").data("ic-event-sse-source");
+              assert.equal('/foo', mockSource.url);
+              assert.equal(true, mockSource.withCredentials);
+            },
+            function (assert) {
+            });
+  </script>
+
+  <div id="sse-8" ic-sse-src="/foo" ic-sse-with-credentials="false">
+  <script>
+    intercoolerTest("test event source with credentials set to false",
+            function (assert) {
+              var mockSource = $("#sse-8").data("ic-event-sse-source");
+              assert.equal('/foo', mockSource.url);
+              assert.equal(false, mockSource.withCredentials);
+            },
+            function (assert) {
+            });
+  </script>
+
+  <div id="sse-9" ic-sse-src="/foo">
+  <script>
+    intercoolerTest("test event source without credentials explicitly set",
+            function (assert) {
+              var mockSource = $("#sse-9").data("ic-event-sse-source");
+              assert.equal('/foo', mockSource.url);
+              assert.equal(false, mockSource.withCredentials);
+            },
+            function (assert) {
+            });
   </script>
 
   <div id="anchor-regression-div">


### PR DESCRIPTION
Addresses #292 .

To support SSE with hubs like Mercure, we need to instantiate `EventSource` with `withCredentials` set to true so that cookies get included in the request. This PR adds an `ic-sse-with-credentials` attribute. When set to `true` on the same element as `ic-sse-src`, the `EventSource` will be set up to include the cookies. 